### PR TITLE
For python 3 compatibility

### DIFF
--- a/object_detection/core/batcher.py
+++ b/object_detection/core/batcher.py
@@ -81,7 +81,7 @@ class BatchQueue(object):
         {key: tensor.get_shape() for key, tensor in tensor_dict.items()})
     # Remember runtime shapes to unpad tensors after batching.
     runtime_shapes = collections.OrderedDict(
-        {(key, 'runtime_shapes'): tf.shape(tensor)
+        {(key + '_runtime_shapes'): tf.shape(tensor)
          for key, tensor in tensor_dict.items()})
     all_tensors = tensor_dict
     all_tensors.update(runtime_shapes)
@@ -112,8 +112,8 @@ class BatchQueue(object):
     for key, batched_tensor in batched_tensors.items():
       unbatched_tensor_list = tf.unstack(batched_tensor)
       for i, unbatched_tensor in enumerate(unbatched_tensor_list):
-        if isinstance(key, tuple) and key[1] == 'runtime_shapes':
-          shapes[(key[0], i)] = unbatched_tensor
+        if '_runtime_shapes' in key:
+          shapes[(key[:-15], i)] = unbatched_tensor
         else:
           tensors[(key, i)] = unbatched_tensor
 


### PR DESCRIPTION
To solve the following error:
```
INFO:tensorflow:Scale of 0 disables regularizer.
INFO:tensorflow:Scale of 0 disables regularizer.
Traceback (most recent call last):
  File "train.py", line 198, in <module>
    tf.app.run()
  File "/home/alibaba/anaconda3/lib/python3.5/site-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "train.py", line 194, in main
    worker_job_name, is_chief, FLAGS.train_dir)
  File "/home/alibaba/data_projects/models/object_detection/trainer.py", line 184, in train
    data_augmentation_options)
  File "/home/alibaba/data_projects/models/object_detection/trainer.py", line 77, in _create_input_queue
    prefetch_queue_capacity=prefetch_queue_capacity)
  File "/home/alibaba/data_projects/models/object_detection/core/batcher.py", line 93, in __init__
    num_threads=num_batch_queue_threads)
  File "/home/alibaba/anaconda3/lib/python3.5/site-packages/tensorflow/python/training/input.py", line 919, in batch
    name=name)
  File "/home/alibaba/anaconda3/lib/python3.5/site-packages/tensorflow/python/training/input.py", line 697, in _batch
    tensor_list = _as_tensor_list(tensors)
  File "/home/alibaba/anaconda3/lib/python3.5/site-packages/tensorflow/python/training/input.py", line 385, in _as_tensor_list
    return [tensors[k] for k in sorted(tensors)]
TypeError: unorderable types: tuple() < str()
```